### PR TITLE
fix(scanner): allow periods in tag names

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -109,7 +109,7 @@ static void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
 
 static String scan_tag_name(TSLexer *lexer) {
     String tag_name = array_new();
-    while (iswalnum(lexer->lookahead) || lexer->lookahead == '-' || lexer->lookahead == ':') {
+    while (iswalnum(lexer->lookahead) || lexer->lookahead == '-' || lexer->lookahead == ':' || lexer->lookahead == '.') {
         array_push(&tag_name, towupper(lexer->lookahead));
         advance(lexer);
     }

--- a/test/corpus/html/main.txt
+++ b/test/corpus/html/main.txt
@@ -119,7 +119,9 @@ Custom tags
 ==================================
 <something:different>
   <atom-text-editor mini>
-    Hello
+    <Hello.World>
+      Hello
+    </Hello.World>
   </atom-text-editor>
 </something:different>
 ---
@@ -133,7 +135,12 @@ Custom tags
         (tag_name)
         (attribute
           (attribute_name)))
-      (text)
+      (element
+        (start_tag
+          (tag_name))
+        (text)
+        (end_tag
+          (tag_name)))
       (end_tag
         (tag_name)))
     (end_tag


### PR DESCRIPTION
Includes periods when scanning tag names to allow for a common design with Svelte components, where multiple components are imported under a single namespace, such as this example from [shadcn-svelte](https://shadcn-svelte.com/docs/components/card):

```svelte
<script lang="ts">
  import * as Card from "$lib/components/ui/card";
</script>

<Card.Root>
  <Card.Header>
    <Card.Title>Card Title</Card.Title>
    <Card.Description>Card Description</Card.Description>
  </Card.Header>
  <Card.Content>
    <p>Card Content</p>
  </Card.Content>
  <Card.Footer>
    <p>Card Footer</p>
  </Card.Footer>
</Card.Root>
```

This problem was mistakenly reported in https://github.com/Himujjal/tree-sitter-svelte/issues/58 which is another Tree-Sitter grammar for Svelte.
