### PR TITLE
Added Stylus support

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -8,7 +8,7 @@
         (attribute_value) @_lang)))
   (raw_text) @injection.content)
   (#eq? @_attr "lang")
-  (#any-of? @_lang "scss" "postcss" "less")
+  (#any-of? @_lang "scss" "postcss" "less" "stylus")
   (#set! injection.language "scss"))
 
 ((raw_text) @injection.content


### PR DESCRIPTION
Syntax highlighting for Stylus works:

![image](https://github.com/user-attachments/assets/caa576b5-6efa-4979-8da1-84e15f0248b7)
